### PR TITLE
Correct astronaut name

### DIFF
--- a/Assets/Resources/astronauts.txt
+++ b/Assets/Resources/astronauts.txt
@@ -344,7 +344,7 @@ Peggy Whitson
 Peru Carlos Noriega 
 Peter Wisoff 
 Pierre Thuot 
-Poland Miroslaw Hermaszewski 
+Miroslaw Hermaszewski 
 Randolph Bresnik
 Rex Walheim 
 Rhea Seddon


### PR DESCRIPTION
"Miroslaw Hermaszewski" was prefixed with the word "Poland", now removed
